### PR TITLE
サインイン状態でGame Start後の遷移先分岐

### DIFF
--- a/src/components/templates/StartButton.vue
+++ b/src/components/templates/StartButton.vue
@@ -1,7 +1,23 @@
 <script setup>
+import { ref, onMounted} from 'vue';
+import { useRoute } from 'vue-router';
+import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import ButtonPart from '../parts/ButtonPart.vue';
+
+const auth = getAuth();
+const isSignedUp = ref(false);
+const router = useRoute();
 const props = defineProps(['isSignedUp'])
 
+onMounted(() => {
+  onAuthStateChanged(auth, (user) => {
+    if (user) {
+      isSignedUp.value = true;
+    } else {
+      isSignedUp.value = false;
+    }
+  });
+});
 </script>
 <template>
   <RouterLink to="/prologue" v-if="isSignedUp">


### PR DESCRIPTION
## topic
topのスタートボタン押下時
現在ログイン済み（セッションあり）の場合にはprologueへ
ログアウト中（セッションなし）の場合にはloginへ
遷移先分岐

## attention
分岐ボタン記述は既存実装を継続利用しています

### 対応箇所
赤丸のメールpw入力スキップor実行の分岐です
![スクリーンショット 2024-03-25 15 32 38](https://github.com/chicobami/duorange/assets/58246272/c34381e5-5fb0-4956-a8c1-f05797843cfe)

